### PR TITLE
Eye toggle button sometimes doesnt work

### DIFF
--- a/apps/client/src/pages/builder/page.tsx
+++ b/apps/client/src/pages/builder/page.tsx
@@ -10,7 +10,7 @@ import { SECTION_MAPPING_KEY } from "@/client/constants/query-keys";
 import { queryClient } from "@/client/libs/query-client";
 import { findResumeById } from "@/client/services/resume";
 import { useSections } from "@/client/services/section/sections";
-import { fetchSectionMappings } from "@/client/services/section-mapping";
+import { fetchSectionMappings, useSectionMappings } from "@/client/services/section-mapping";
 import { useBuilderStore } from "@/client/stores/builder";
 import { useResumeStore } from "@/client/stores/resume";
 import { useSectionMappingStore } from "@/client/stores/section-mapping";
@@ -52,6 +52,8 @@ export const BuilderPage = () => {
   const setMappings = useSectionMappingStore((state) => state.setMappings);
 
   useSections();
+
+  useSectionMappings(resume.id);
 
   const syncResumeToArtboard = useCallback(() => {
     const latestMappings = useSectionMappingStore.getState().mappings;


### PR DESCRIPTION
We use the loader to fetch the mappings, which is "necessary" to ensure the data is present on first render, but we still also need to use the react query hook, to make sure it refetches when the querykey is invalidated.

So adding the hook back solves this issue, but the issue is that it causes the section mappings api to be called twice on first load of the page. 

But fixing that issue is a much larger task, and for now this seems like a fine trade off to solve this rather annoying bug quickly.