### PR TITLE
Fixing azurite/azureblobstorage locally

### DIFF
--- a/apps/server/src/config/schema.ts
+++ b/apps/server/src/config/schema.ts
@@ -33,6 +33,8 @@ export const configSchema = z.object({
     .refine((url) => url.startsWith("smtp://") || url.startsWith("smtps://"))
     .optional(),
 
+  // ---STORAGE---
+  STORAGE_TYPE: z.string().default("azure_blob_storage"),
   // Azure Blob Storage
 
   AZURE_ACCOUNT_NAME: z.string(),

--- a/apps/server/src/storage/storage.module.ts
+++ b/apps/server/src/storage/storage.module.ts
@@ -18,6 +18,7 @@ import { StorageService } from "./storage.service";
         containerName: configService.getOrThrow<string>("AZURE_STORAGE_CONTAINER"),
         skipContainerCheck: configService.getOrThrow<boolean>("STORAGE_SKIP_BUCKET_CHECK"),
         storageUrl: configService.getOrThrow<string>("STORAGE_URL"),
+        storageType: configService.get<string>("STORAGE_TYPE"),
       }),
     },
     StorageService,

--- a/apps/server/src/storage/storage.service.ts
+++ b/apps/server/src/storage/storage.service.ts
@@ -29,12 +29,20 @@ export class StorageService implements OnModuleInit {
     const accountKey = this.configService.getOrThrow<string>("AZURE_ACCOUNT_KEY");
     const containerName = this.configService.getOrThrow<string>("AZURE_STORAGE_CONTAINER");
     const skipContainerCheck = this.configService.getOrThrow<boolean>("STORAGE_SKIP_BUCKET_CHECK");
-
+    const storageType = this.configService.getOrThrow<string>("STORAGE_TYPE");
     const credentials = new StorageSharedKeyCredential(accountName, accountKey);
-    this.blobServiceClient = new BlobServiceClient(
-      `https://${accountName}.blob.core.windows.net`,
-      credentials,
-    );
+    if (storageType == "azurite") {
+      this.logger.warn("Azurite storage type is not supported in production.");
+      this.blobServiceClient = new BlobServiceClient(
+        `http://localhost:10000/${accountName}`,
+        credentials,
+      );
+    } else {
+      this.blobServiceClient = new BlobServiceClient(
+        `https://${accountName}.blob.core.windows.net`,
+        credentials,
+      );
+    }
     this.containerClient = this.blobServiceClient.getContainerClient(containerName);
 
     if (skipContainerCheck) {

--- a/tools/compose/development.yml
+++ b/tools/compose/development.yml
@@ -35,20 +35,14 @@ services:
       ADMINER_DEFAULT_DB: ${POSTGRES_DB:-postgres}
 
   # Storage (for image uploads)
-  minio:
-    image: minio/minio:latest
+  azurite:
+    image: mcr.microsoft.com/azure-storage/azurite
     restart: unless-stopped
-    command: server /data
+    command: azurite-blob --loose --blobHost 0.0.0.0
     ports:
-      - ${STORAGE_PORT:-9000}:9000
-      - "9001:9001" # Minio Console (Optional)
+      - "10000:10000" # Blob service (HTTP only)
     volumes:
-      - minio_data:/data
-    environment:
-      MINIO_ADDRESS: :9000
-      MINIO_CONSOLE_ADDRESS: :9001
-      MINIO_ROOT_USER: ${STORAGE_ACCESS_KEY:-minioadmin}
-      MINIO_ROOT_PASSWORD: ${STORAGE_SECRET_KEY:-minioadmin}
+      - azurite_data:/data
 
   # Chrome Browser (for printing and previews)
   chrome:
@@ -64,5 +58,5 @@ services:
       PROXY_SSL: "false"
 
 volumes:
-  minio_data:
+  azurite_data:
   postgres_data:

--- a/tools/compose/nginx-proxy-manager.yml
+++ b/tools/compose/nginx-proxy-manager.yml
@@ -21,21 +21,14 @@ services:
       retries: 5
 
   # Storage (for image uploads)
-  minio:
-    image: minio/minio:latest
+  azurite:
+    image: mcr.microsoft.com/azure-storage/azurite
     restart: unless-stopped
-    command: server /data
+    command: azurite-blob --loose --blobHost 0.0.0.0
+    ports:
+      - "10000:10000" # Blob service (HTTP only)
     volumes:
-      - minio_data:/data
-    environment:
-      MINIO_ROOT_USER: minioadmin
-      MINIO_ROOT_PASSWORD: minioadmin
-    labels:
-      - traefik.enable=true
-      - traefik.http.routers.storage.rule=Host(`storage.example.com`)
-      - traefik.http.routers.storage.entrypoints=websecure
-      - traefik.http.routers.storage.tls.certresolver=letsencrypt
-      - traefik.http.services.storage.loadbalancer.server.port=9000
+      - azurite_data:/data
 
   # Chrome Browser (for printing and previews)
   chrome:
@@ -79,15 +72,12 @@ services:
       MAIL_FROM: noreply@example.com
       # SMTP_URL: smtp://user:pass@smtp:587 # Optional
 
-      # -- Storage (Minio) --
-      STORAGE_ENDPOINT: minio
-      STORAGE_PORT: 9000
-      STORAGE_REGION: us-east-1 # Optional
-      STORAGE_BUCKET: default
-      STORAGE_ACCESS_KEY: minioadmin
-      STORAGE_SECRET_KEY: minioadmin
-      STORAGE_USE_SSL: "false"
-      STORAGE_SKIP_BUCKET_CHECK: "false"
+      # -- Storage (azurite) --
+      AZURE_ACCOUNT_NAME: devstoreaccount1
+      AZURE_ACCOUNT_KEY: Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==
+      AZURE_STORAGE_CONTAINER: images
+
+      STORAGE_TYPE: azurite
 
       # -- Crowdin (Optional) --
       # CROWDIN_PROJECT_ID:
@@ -132,7 +122,7 @@ services:
       DISABLE_IPV6: "true"
 
 volumes:
-  minio_data:
+  azurite_data:
   nginx_data:
   postgres_data:
   letsencrypt_data:

--- a/tools/compose/simple.yml
+++ b/tools/compose/simple.yml
@@ -20,17 +20,14 @@ services:
       retries: 5
 
   # Storage (for image uploads)
-  minio:
-    image: minio/minio:latest
+  azurite:
+    image: mcr.microsoft.com/azure-storage/azurite
     restart: unless-stopped
-    command: server /data
+    command: azurite-blob --loose --blobHost 0.0.0.0
     ports:
-      - "9000:9000"
+      - "10000:10000" # Blob service (HTTP only)
     volumes:
-      - minio_data:/data
-    environment:
-      MINIO_ROOT_USER: minioadmin
-      MINIO_ROOT_PASSWORD: minioadmin
+      - azurite_data:/data
 
   # Chrome Browser (for printing and previews)
   chrome:
@@ -61,7 +58,7 @@ services:
 
       # -- URLs --
       PUBLIC_URL: http://localhost:3000
-      STORAGE_URL: http://localhost:9000/default
+      STORAGE_URL: http://localhost:10000/devstoreaccount1/images
 
       # -- Printer (Chrome) --
       CHROME_TOKEN: chrome_token
@@ -78,16 +75,14 @@ services:
       MAIL_FROM: noreply@localhost
       # SMTP_URL: smtp://user:pass@smtp:587 # Optional
 
-      # -- Storage (Minio) --
-      STORAGE_ENDPOINT: minio
-      STORAGE_PORT: 9000
-      STORAGE_REGION: us-east-1 # Optional
-      STORAGE_BUCKET: default
-      STORAGE_ACCESS_KEY: minioadmin
-      STORAGE_SECRET_KEY: minioadmin
-      STORAGE_USE_SSL: "false"
-      STORAGE_SKIP_BUCKET_CHECK: "false"
+      # -- Storage (azurite) --
+      AZURE_ACCOUNT_NAME: devstoreaccount1
+      AZURE_ACCOUNT_KEY: Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==
+      AZURE_STORAGE_CONTAINER: images
 
+      STORAGE_TYPE: azurite
+
+      ## -- OPENAI KEY --
       OPENAI_API_KEY: ${OPENAI_API_KEY}
 
       # -- Crowdin (Optional) --
@@ -120,5 +115,5 @@ services:
       # OPENID_USER_INFO_URL:
 
 volumes:
-  minio_data:
+  azurite_data:
   postgres_data:

--- a/tools/compose/traefik.yml
+++ b/tools/compose/traefik.yml
@@ -23,19 +23,14 @@ services:
       retries: 5
 
   # Storage (for image uploads)
-  minio:
-    image: minio/minio:latest
+  azurite:
+    image: mcr.microsoft.com/azure-storage/azurite
     restart: unless-stopped
-    command: server /data
+    command: azurite-blob --loose --blobHost 0.0.0.0
+    ports:
+      - "10000:10000" # Blob service (HTTP only)
     volumes:
-      - minio_data:/data
-    environment:
-      MINIO_ROOT_USER: minioadmin
-      MINIO_ROOT_PASSWORD: minioadmin
-    labels:
-      - traefik.enable=true
-      - traefik.http.routers.storage.rule=Host(`storage.example.com`)
-      - traefik.http.services.storage.loadbalancer.server.port=9000
+      - azurite_data:/data
 
   # Chrome Browser (for printing and previews)
   chrome:
@@ -139,5 +134,5 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
 
 volumes:
-  minio_data:
+  azurite_data:
   postgres_data:

--- a/tools/scripts/apply-vector-migration.js
+++ b/tools/scripts/apply-vector-migration.js
@@ -2,30 +2,54 @@ const { Client } = require("pg");
 const fs = require("fs");
 const path = require("path");
 require("dotenv").config({ path: path.resolve(__dirname, "../../.env") });
-const runMigration = async () => {
-  const client = new Client({
-    connectionString: process.env.DATABASE_URL,
-    password: process.env.POSTGRES_PASSWORD,
-    user: process.env.POSTGRES_USER,
-    database: process.env.POSTGRES_DB,
-    ssl: { rejectUnauthorized: false },
-  });
 
+// Function to run migration given a client config
+const runMigrationWithConfig = async (config) => {
+  const client = new Client(config);
   try {
     await client.connect();
-
-    const sql = fs.readFileSync(path.join(__dirname, "../postgres/pgvectorCreate.sql"), "utf8");
+    const sqlPath = path.join(__dirname, "../postgres/pgvectorCreate.sql");
+    const sql = fs.readFileSync(sqlPath, "utf8");
     await client.query(sql);
-
-    console.log("Additional migration applied successfully.");
-  } catch (err) {
-    console.error("Error applying additional migration:", err);
+    console.log(
+      `Additional migration applied successfully with ssl: ${JSON.stringify(config.ssl)}.`,
+    );
   } finally {
     await client.end();
   }
 };
 
+const runMigration = async () => {
+  // Shared configuration for the client
+  const baseConfig = {
+    connectionString: process.env.DATABASE_URL,
+    user: process.env.POSTGRES_USER,
+    password: process.env.POSTGRES_PASSWORD,
+    database: process.env.POSTGRES_DB,
+  };
+
+  // First attempt with SSL enabled
+  const configWithSSL = { ...baseConfig, ssl: { rejectUnauthorized: false } };
+  try {
+    await runMigrationWithConfig(configWithSSL);
+  } catch (err) {
+    if (err.message.includes("does not support SSL connections")) {
+      console.warn("SSL not supported by the server, retrying migration without SSL...");
+      const configNoSSL = { ...baseConfig, ssl: false };
+      try {
+        await runMigrationWithConfig(configNoSSL);
+      } catch (err2) {
+        console.error("Error applying additional migration without SSL:", err2);
+        process.exit(1);
+      }
+    } else {
+      console.error("Error applying additional migration:", err);
+      process.exit(1);
+    }
+  }
+};
+
 runMigration().catch((err) => {
-  console.error("Error applying additional migration:", err);
+  console.error("Unexpected error during migration:", err);
   process.exit(1);
 });


### PR DESCRIPTION
I fixed azurite so that you can run Azurite  (Containerized version of azure blob storage) via the docker compose file. It requires slight different logic via the endpoint which is why I have added an extra field in the env which determines which storage type you want to use. My idea is we can reimplement minio and use a strategy pattern.

The .env files work as they should now with the deployed azure blob storage, but I will add a env file in discord in case you are interested in running everything locally.

Plus I sneaked in a hot fix to the script that deploys vector embedding